### PR TITLE
fix(api): address PR #56 review feedback for FaultSpec conversion

### DIFF
--- a/src/cmd/aegisctl/cmd/inject.go
+++ b/src/cmd/aegisctl/cmd/inject.go
@@ -138,7 +138,7 @@ SUPPORTED FAULT TYPES:
 
 NOTE: --project is required for submit, list, and search commands.
       It accepts project names (resolved to IDs automatically).
-      The 'target' field accepts container names (resolved to indices automatically).
+      The 'target' field accepts numeric container indices (use 'aegisctl inject metadata' to look up indices).
       Duration accepts Go time strings: "60s", "5m", "1h", etc.`,
 }
 

--- a/src/cmd/aegisctl/cmd/inject.go
+++ b/src/cmd/aegisctl/cmd/inject.go
@@ -122,7 +122,7 @@ SPEC FILE FORMAT (injection.yaml):
   specs:
     - - type: CPUStress
         namespace: exp
-        target: frontend
+        target: "0"
         duration: "5m"
         params:
           cpu_load: 80

--- a/src/service/producer/spec_convert.go
+++ b/src/service/producer/spec_convert.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -195,14 +196,15 @@ func mapParamsToFieldIndices(params map[string]any, specType any, children map[s
 			idx, ok = nameToIdx[strings.ToLower(key)]
 		}
 		if !ok {
-			available := make([]string, 0, len(nameToIdx))
-			seen := make(map[int]bool)
-			for name, fieldIdx := range nameToIdx {
-				if !seen[fieldIdx] {
-					seen[fieldIdx] = true
-					available = append(available, name)
+			available := make([]string, 0, rt.NumField()-3)
+			for i := 3; i < rt.NumField(); i++ {
+				field := rt.Field(i)
+				if field.Name == "NamespaceTarget" {
+					continue
 				}
+				available = append(available, toSnakeCase(field.Name))
 			}
+			sort.Strings(available)
 			return fmt.Errorf("unknown param %q, available fields: %v", key, available)
 		}
 

--- a/src/service/producer/spec_convert.go
+++ b/src/service/producer/spec_convert.go
@@ -61,7 +61,7 @@ func FriendlySpecToNode(spec *dto.FriendlyFaultSpec) (chaos.Node, error) {
 	// Resolve target to a numeric index.
 	// The target field maps to the 3rd field (index 2) of the spec struct,
 	// which is ContainerIdx, AppIdx, etc. depending on the fault type.
-	// If target is a numeric string, use it directly. Otherwise default to 0.
+	// Target must be a numeric string or empty (defaults to 0).
 	targetIdx, err := resolveTargetIndex(spec.Target)
 	if err != nil {
 		return chaos.Node{}, fmt.Errorf("failed to resolve target %q: %w", spec.Target, err)
@@ -131,16 +131,9 @@ func resolveNamespaceIndex(namespace string) (int, error) {
 		return 0, nil
 	}
 
-	// Exact match
+	// Exact match only
 	for idx, prefix := range chaos.NamespacePrefixs {
 		if prefix == namespace {
-			return idx, nil
-		}
-	}
-
-	// Prefix-based match (e.g., "exp" matches "exp" prefix)
-	for idx, prefix := range chaos.NamespacePrefixs {
-		if strings.HasPrefix(prefix, namespace) || strings.HasPrefix(namespace, prefix) {
 			return idx, nil
 		}
 	}
@@ -149,8 +142,8 @@ func resolveNamespaceIndex(namespace string) (int, error) {
 }
 
 // resolveTargetIndex resolves the target field to a numeric index.
-// If target is numeric, parse it directly. If it's a name string, return 0 with
-// a note that the downstream pipeline will validate against the actual cluster state.
+// If target is empty, defaults to 0. If numeric, parses directly.
+// Non-numeric non-empty targets return an error.
 func resolveTargetIndex(target string) (int, error) {
 	if target == "" {
 		return 0, nil
@@ -161,12 +154,8 @@ func resolveTargetIndex(target string) (int, error) {
 		return idx, nil
 	}
 
-	// Non-numeric target: the name-to-index resolution requires K8s cluster state
-	// (via resourcelookup, which is internal to chaos-experiment).
-	// Return 0 as default — users should use the `aegisctl inject metadata` command
-	// to look up numeric indices for named targets before submission.
-	// TODO: When chaos-experiment exposes public lookup APIs, resolve names here.
-	return 0, nil
+	// Non-numeric, non-empty target is an error — users must use numeric indices.
+	return 0, fmt.Errorf("target %q is not a valid numeric index; use 'aegisctl inject metadata' to look up numeric indices", target)
 }
 
 // getSpecType returns the zero-value spec struct for a given ChaosType index.
@@ -206,8 +195,15 @@ func mapParamsToFieldIndices(params map[string]any, specType any, children map[s
 			idx, ok = nameToIdx[strings.ToLower(key)]
 		}
 		if !ok {
-			// Unknown params are silently skipped to allow forward compatibility
-			continue
+			available := make([]string, 0, len(nameToIdx))
+			seen := make(map[int]bool)
+			for name, fieldIdx := range nameToIdx {
+				if !seen[fieldIdx] {
+					seen[fieldIdx] = true
+					available = append(available, name)
+				}
+			}
+			return fmt.Errorf("unknown param %q, available fields: %v", key, available)
 		}
 
 		intVal, err := toInt(val)
@@ -221,13 +217,23 @@ func mapParamsToFieldIndices(params map[string]any, specType any, children map[s
 	return nil
 }
 
-// toSnakeCase converts CamelCase to snake_case (e.g., "CPULoad" → "cpu_load").
+// toSnakeCase converts CamelCase to snake_case, handling consecutive uppercase runs.
+// e.g., "CPULoad" → "cpu_load", "CPUWorker" → "cpu_worker", "MemorySize" → "memory_size".
 func toSnakeCase(s string) string {
 	var result strings.Builder
-	for i, r := range s {
+	runes := []rune(s)
+	for i, r := range runes {
 		if r >= 'A' && r <= 'Z' {
 			if i > 0 {
-				result.WriteByte('_')
+				prev := runes[i-1]
+				// Insert underscore on lowercase→uppercase transition,
+				// or when this uppercase letter is followed by a lowercase letter
+				// (end of an uppercase run, e.g., the 'L' in "CPULoad").
+				if prev >= 'a' && prev <= 'z' {
+					result.WriteByte('_')
+				} else if prev >= 'A' && prev <= 'Z' && i+1 < len(runes) && runes[i+1] >= 'a' && runes[i+1] <= 'z' {
+					result.WriteByte('_')
+				}
 			}
 			result.WriteRune(r + ('a' - 'A'))
 		} else {

--- a/src/service/producer/spec_convert_test.go
+++ b/src/service/producer/spec_convert_test.go
@@ -25,8 +25,6 @@ func TestFriendlySpecToNode_CPUStress(t *testing.T) {
 		Target:    "0", // container index as string
 		Duration:  "5m",
 		Params: map[string]any{
-			// Note: the local toSnakeCase produces "c_p_u_load" for "CPULoad",
-			// so we use the exact field name which is also accepted by mapParamsToFieldIndices.
 			"CPULoad":   80,
 			"CPUWorker": 2,
 		},
@@ -235,8 +233,7 @@ func TestFriendlySpecToNode_ParamsMapping(t *testing.T) {
 	setupNamespacePrefixes(t)
 
 	// Test that named params are correctly mapped to field indices via reflection.
-	// The local toSnakeCase produces "c_p_u_load" for "CPULoad" (not "cpu_load"),
-	// but mapParamsToFieldIndices also accepts exact field names and lowercase field names.
+	// mapParamsToFieldIndices accepts exact field names, lowercase field names, and snake_case names.
 	// JSON numbers are float64, so pass float64 values.
 	spec := &dto.FriendlyFaultSpec{
 		Type:      "CPUStress",
@@ -459,12 +456,9 @@ func TestFriendlySpecToNode_LowercaseParamNames(t *testing.T) {
 	}
 }
 
-func TestFriendlySpecToNode_SnakeCaseParamsMismatch(t *testing.T) {
+func TestFriendlySpecToNode_SnakeCaseParams(t *testing.T) {
 	setupNamespacePrefixes(t)
 
-	// The local toSnakeCase("CPULoad") = "c_p_u_load" (not "cpu_load").
-	// So "cpu_load" does NOT match and the param is silently skipped.
-	// This documents the known limitation.
 	spec := &dto.FriendlyFaultSpec{
 		Type:      "CPUStress",
 		Namespace: "ts",
@@ -485,9 +479,65 @@ func TestFriendlySpecToNode_SnakeCaseParamsMismatch(t *testing.T) {
 		t.Fatal("expected child key '4'")
 	}
 
-	// "cpu_load" doesn't match any registered key, so it's silently skipped
-	if _, ok := typeChild.Children["3"]; ok {
-		t.Error("did not expect child '3' (CPULoad) when using 'cpu_load' param key (snake_case mismatch)")
+	// After toSnakeCase fix, "cpu_load" should now match CPULoad (field index 3)
+	if cpuLoad, ok := typeChild.Children["3"]; ok {
+		if cpuLoad.Value != 80 {
+			t.Errorf("expected CPULoad=80, got %d", cpuLoad.Value)
+		}
+	} else {
+		t.Error("expected child '3' (CPULoad) to exist via snake_case key 'cpu_load'")
+	}
+}
+
+func TestFriendlySpecToNode_UnknownParamError(t *testing.T) {
+	setupNamespacePrefixes(t)
+
+	spec := &dto.FriendlyFaultSpec{
+		Type:      "CPUStress",
+		Namespace: "ts",
+		Target:    "0",
+		Duration:  "5m",
+		Params: map[string]any{
+			"nonexistent_param": float64(99),
+		},
+	}
+
+	_, err := FriendlySpecToNode(spec)
+	if err == nil {
+		t.Fatal("expected error for unknown param, got nil")
+	}
+}
+
+func TestFriendlySpecToNode_NonNumericTargetError(t *testing.T) {
+	setupNamespacePrefixes(t)
+
+	spec := &dto.FriendlyFaultSpec{
+		Type:      "CPUStress",
+		Namespace: "ts",
+		Target:    "frontend", // non-numeric, should error
+		Duration:  "5m",
+	}
+
+	_, err := FriendlySpecToNode(spec)
+	if err == nil {
+		t.Fatal("expected error for non-numeric target, got nil")
+	}
+}
+
+func TestFriendlySpecToNode_LooseNamespaceNoMatch(t *testing.T) {
+	setupNamespacePrefixes(t)
+	// "ts" is the only registered prefix
+
+	spec := &dto.FriendlyFaultSpec{
+		Type:      "CPUStress",
+		Namespace: "t", // "t" should NOT match "ts" anymore (strict matching)
+		Target:    "0",
+		Duration:  "5m",
+	}
+
+	_, err := FriendlySpecToNode(spec)
+	if err == nil {
+		t.Fatal("expected error for namespace 't' not matching 'ts' (strict matching), got nil")
 	}
 }
 
@@ -582,9 +632,6 @@ func TestParseDurationToMinutes(t *testing.T) {
 }
 
 func TestToSnakeCase(t *testing.T) {
-	// Note: the local toSnakeCase implementation inserts underscore before each uppercase letter,
-	// which is simpler than the chaos-experiment utils.ToSnakeCase (regex-based).
-	// "CPULoad" -> "c_p_u_load" with the simple approach.
 	tests := []struct {
 		input    string
 		expected string
@@ -593,6 +640,10 @@ func TestToSnakeCase(t *testing.T) {
 		{"Namespace", "namespace"},
 		{"MemorySize", "memory_size"},
 		{"", ""},
+		{"CPULoad", "cpu_load"},
+		{"CPUWorker", "cpu_worker"},
+		{"HTTPDelay", "http_delay"},
+		{"ContainerIdx", "container_idx"},
 	}
 
 	for _, tc := range tests {
@@ -606,18 +657,21 @@ func TestToSnakeCase(t *testing.T) {
 }
 
 func TestToSnakeCase_ConsecutiveUppercase(t *testing.T) {
-	// The simple toSnakeCase inserts _ before every uppercase letter:
-	// "CPULoad" -> "c_p_u_load"
-	// Verify actual behavior rather than assuming.
-	result := toSnakeCase("CPULoad")
-	// Just verify it returns a non-empty string and is lowercase
-	if result == "" {
-		t.Error("expected non-empty result for CPULoad")
+	tests := []struct{ input, expected string }{
+		{"CPULoad", "cpu_load"},
+		{"CPUWorker", "cpu_worker"},
+		{"HTTPDelay", "http_delay"},
+		{"DNSError", "dns_error"},
+		{"IOLatency", "io_latency"},
 	}
-	t.Logf("toSnakeCase(\"CPULoad\") = %q", result)
-
-	result2 := toSnakeCase("ContainerIdx")
-	t.Logf("toSnakeCase(\"ContainerIdx\") = %q", result2)
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			result := toSnakeCase(tc.input)
+			if result != tc.expected {
+				t.Errorf("toSnakeCase(%q) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
 }
 
 func TestToInt(t *testing.T) {


### PR DESCRIPTION
## Summary
Addresses the 4 REQUEST_CHANGES items from PR #56 review:

1. **toSnakeCase bug fixed** — consecutive uppercase now handled correctly: `CPULoad` → `cpu_load` (was `c_p_u_load`)
2. **Unknown params return error** — `mapParamsToFieldIndices` now returns an error with available field names instead of silently skipping unrecognized params
3. **Non-numeric target returns error** — `resolveTargetIndex` rejects non-numeric targets with a clear message pointing to `aegisctl inject metadata`
4. **Namespace matching strict** — removed bidirectional `HasPrefix`; only exact match is accepted now

## Test plan
- [x] `go build -tags duckdb_arrow` passes
- [x] `go test ./service/producer/... -v` — 27/27 pass (3 new tests added)
- [x] `go test ./dto/... -v` — 10/10 pass
- [x] New tests: `TestFriendlySpecToNode_UnknownParamError`, `TestFriendlySpecToNode_NonNumericTargetError`, `TestFriendlySpecToNode_LooseNamespaceNoMatch`
- [x] Updated tests: `TestToSnakeCase` + `TestToSnakeCase_ConsecutiveUppercase` assert correct snake_case for CPULoad/HTTPDelay/etc
- [x] `TestFriendlySpecToNode_SnakeCaseParams` now confirms `cpu_load` matches (was a known failure)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)